### PR TITLE
fix--core-tslib

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist",
+    "importHelpers": false,
     "tsBuildInfoFile": "dist/.tsbuildinfo"
   },
   "include": [


### PR DESCRIPTION
Remove dependency on tslib when using core package as an NPM dependency