### PR TITLE
Better Menus

### DIFF
--- a/packages/media/app/main/src/menu.ts
+++ b/packages/media/app/main/src/menu.ts
@@ -1,18 +1,53 @@
-import { Menu, shell } from 'electron'
+import { app, Menu, shell } from 'electron'
 import { MenuItemConstructorOptions } from 'electron/main'
 
-const appName = 'Library Media'
-const template: MenuItemConstructorOptions[] = [
-  {
-    label: appName,
+const isMac = process.platform === 'darwin'
+
+const template: MenuItemConstructorOptions[] = []
+
+if (isMac) {
+  template.push({
+    label: app.name,
     submenu: [
-      { role: 'about', label: `About ${appName}` },
-      { role: 'quit', label: 'Quit' }
+      { role: 'about' },
+      { type: 'separator' },
+      { role: 'services' },
+      { type: 'separator' },
+      { role: 'hide' },
+      { type: 'separator' },
+      { role: 'quit' }
+    ]
+  })
+}
+template.push(
+  {
+    label: 'File',
+    submenu: [
+      isMac ? { role: 'close' } : { role: 'quit' }
     ]
   },
   {
-    label: 'Help',
+    label: 'View',
     submenu: [
+      { role: 'togglefullscreen' }
+    ]
+  },
+  {
+    label: 'Window',
+    submenu: [
+      { role: 'minimize' },
+      { role: 'zoom' }
+    ]
+  },
+  {
+    role: 'help',
+    submenu: [
+      {
+        label: 'Open Change Log',
+        click: async () => {
+          await shell.openExternal('https://github.com/BenShelton/library-api/blob/master/packages/media/CHANGELOG.md')
+        }
+      },
       {
         label: 'Open Documentation',
         click: async () => {
@@ -21,7 +56,7 @@ const template: MenuItemConstructorOptions[] = [
       }
     ]
   }
-]
+)
 
 export function initMenu (): void {
   const menu = Menu.buildFromTemplate(template)

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@library-api/media",
+  "productName": "Library Media",
   "private": true,
   "version": "0.10.1",
   "description": "A cross-platform application that simplifies showing media for meetings of Jehovah's Witnesses.",


### PR DESCRIPTION
Adds more menu items.

Because this changes the `productName` the `appData` directory is changed to `Application Support/Library Media` instead of `Application Support/@library-api/media`.
Before this can be merged we need to do a soft migration of the `downloads` and `config.json` files from the old support directory to the new one to avoid having to download everything again.